### PR TITLE
Restricted ability to accept starters only to users who own the Revisore role

### DIFF
--- a/cogs/reviews.py
+++ b/cogs/reviews.py
@@ -2,12 +2,12 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import MemberConverter
 from discord.ext.commands import PartialEmojiConverter
-from discord.ext.commands.errors import MemberNotFound
+
 
 class Reviews(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-    
+
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
 
@@ -20,21 +20,36 @@ class Reviews(commands.Cog):
             emoji_converter = PartialEmojiConverter()
             verify_emoji = await emoji_converter.convert(ctx, '<:Verified:707278127449112616>')
 
+            # Gets the reactor user and check if it has the role revisore
+            reactor = guild.get_member(payload.user_id)
+            revisore_role = guild.get_role(830888232609906698)
+            log_channel = guild.get_channel(697438179975888966)
+
+            # If the user has not the role revisore, the reaction is removed
+            if not revisore_role in reactor.roles:
+                embed = discord.Embed(
+                    description="<@%d> ha provato ad accettare un membro senza permesso" % (
+                        payload.user_id),
+                    color=discord.Color.red()
+                )
+                await log_channel.send(content=revisore_role.mention, embed=embed)
+                await message.remove_reaction(verify_emoji, reactor)
+                return
+
             # check if the message was sent by the bot
             if payload.emoji == verify_emoji:
-            
+
                 username = message.embeds[0].fields[0].value
                 ign = message.embeds[0].fields[1].value
                 macroregion = message.embeds[0].fields[4].value
                 city = str(message.embeds[0].fields[5].value).title()
-                revisore_role = guild.get_role(830888232609906698)
-                log_channel = guild.get_channel(697438179975888966)
-                
+
                 try:
                     converter = MemberConverter()
                     member = await converter.convert(ctx, username)
                 except commands.MemberNotFound:
-                    embed=discord.Embed(description="Member not found.", color=discord.Color.red())
+                    embed = discord.Embed(
+                        description="Member not found.", color=discord.Color.red())
                     await log_channel.send(content=revisore_role.mention, embed=embed)
                     return
 
@@ -61,61 +76,36 @@ class Reviews(commands.Cog):
                         await log_channel.send(content=revisore_role.mention, embed=embed)
                         return
 
+                        # send a notification
+                        await notifiche_channel.send(notification_message)
+
+                        # gives starter role and macroregion role
+                        await member.add_roles(starter_role)
+
+                        # edits user nickname
+                        await member.edit(nick=f'{member.name} [{city}]')
+
+                        # run command in #console
+                        await console_channel.send(f'lp user {ign} group add starter')
+
                     if macroregion == 'NORD':
-
-                        # send a notification
-                        await notifiche_channel.send(notification_message)
-
-                        # gives starter role and macroregion role
-                        await member.add_roles(starter_role)
                         await member.add_roles(nord_role)
-
-                        # edits user nickname
-                        await member.edit(nick=f'{member.name} [{city}]')
-
-                        # run command in #console
-                        await console_channel.send(f'lp user {ign} group add starter')
-
-
                     elif macroregion == 'CENTRO':
-                        # send a notification
-                        await notifiche_channel.send(notification_message)
-
-                        # gives starter role and macroregion role
-                        await member.add_roles(starter_role)
                         await member.add_roles(centro_role)
-
-                        # edits user nickname
-                        await member.edit(nick=f'{member.name} [{city}]')
-
-                        # run command in #console
-                        await console_channel.send(f'lp user {ign} group add starter')
-
-
                     elif macroregion == 'SUD':
-                        # send a notification
-                        await notifiche_channel.send(notification_message)
-
-                        # gives starter role and macroregion role
-                        await member.add_roles(starter_role)
                         await member.add_roles(sud_role)
-
-                        # edits user nickname
-                        await member.edit(nick=f'{member.name} [{city}]')
-
-                        # run command in #console
-                        await console_channel.send(f'lp user {ign} group add starter')
-
                     else:
-                        embed=discord.Embed(description='Macroregion not found.', color=discord.Color.red())
+                        embed = discord.Embed(
+                            description='Macroregion not found.', color=discord.Color.red())
                         await log_channel.send(content=revisore_role.mention, embed=embed)
 
                 else:
-                    embed=discord.Embed(description="Member is not in the server or has no roles.", color=discord.Color.red())
+                    embed = discord.Embed(
+                        description="Member is not in the server or has no roles.", color=discord.Color.red())
                     await log_channel.send(content=revisore_role.mention, embed=embed)
-            
+
             elif payload.emoji == '❌':
-                
+
                 username = message.embeds[0].fields[0].value
                 notifiche_channel = guild.get_channel(697169688005836810)
                 log_channel = guild.get_channel(697438179975888966)
@@ -127,26 +117,26 @@ class Reviews(commands.Cog):
                 try:
                     converter = MemberConverter()
                     member = await converter.convert(ctx, username)
-                
+
                 except commands.MemberNotFound:
-                    embed=discord.Embed(description="Member not found.", color=discord.Color.red())
+                    embed = discord.Embed(
+                        description="Member not found.", color=discord.Color.red())
                     await log_channel.send(content=revisore_role.mention, embed=embed)
                     return
 
-
-                if italiano_role in member.roles:    
-                    message=f'Ci dispiace {member.mention}!\La tua applicazione è stata rigettata, chiedi in {supporto_channel.mention} la motivazione.'
+                if italiano_role in member.roles:
+                    message = f'Ci dispiace {member.mention}!\La tua applicazione è stata rigettata, chiedi in {supporto_channel.mention} la motivazione.'
                     await notifiche_channel.send(message)
 
                 elif international_role in member.roles:
-                    message=f"Sorry, {member.mention}!\Your application has been denied, ask in {supporto_channel.mention} the reason."
+                    message = f"Sorry, {member.mention}!\Your application has been denied, ask in {supporto_channel.mention} the reason."
                     await notifiche_channel.send(message)
-                
+
                 else:
-                    embed=discord.Embed(description="Member has no roles.", color=discord.Color.red())
+                    embed = discord.Embed(
+                        description="Member has no roles.", color=discord.Color.red())
                     await log_channel.send(content=revisore_role.mention, embed=embed)
 
 
 def setup(bot):
     bot.add_cog(Reviews(bot))
-    


### PR DESCRIPTION
### Why?
I was able to accept someone without having the role
![My reaction](https://user-images.githubusercontent.com/34315725/133889782-bbdbf00d-dd01-4c70-b211-ce4a6744085c.png)
![Bot message](https://user-images.githubusercontent.com/34315725/133889797-b681d2f0-4eb6-4043-b02a-974d49edf51c.png)

### What did i edit?
1. Added user role check
2. Taken out pieces of common code from the macroregion check

**I have not tested it yet.**